### PR TITLE
Allow downloading tweets by hashtag or cashtag

### DIFF
--- a/docs/content/examples.md
+++ b/docs/content/examples.md
@@ -59,6 +59,34 @@ for user in users:
 
 ```
 
+### How to scrape tweets related to hashtag or cashtag.
+```python
+from pprint import pprint
+
+import nitter_scraper
+from nitter_scraper import NitterScraper
+
+queries = ["#ToTheMoon", "$USDT"]
+
+print("Scraping with local nitter docker instance.")
+
+with NitterScraper(host="0.0.0.0", port=8008) as nitter:
+    for query in queries:
+        for tweet in nitter.get_tweets(query, pages=2):
+            print()
+            pprint(tweet.dict())
+            print(tweet.json(indent=4))
+
+print("Scraping from https://www.nitter.net.")
+
+for query in queries:
+    for tweet in nitter.get_tweets(query, pages=2):
+        print()
+        pprint(tweet.dict())
+        print(tweet.json(indent=4))
+
+```
+
 ### How to poll a users profile for the latest tweet.
 ```python
 import time

--- a/nitter_scraper/nitter.py
+++ b/nitter_scraper/nitter.py
@@ -113,7 +113,7 @@ class Nitter(DockerBase):
         """
         return get_profile(username=username, not_found_ok=not_found_ok, address=self.address)
 
-    def get_tweets(self, username: str, pages: int = 25, break_on_tweet_id: Optional[int] = None):
+    def get_tweets(self, query_string: str, query_type: str, pages: int = 25, break_on_tweet_id: Optional[int] = None):
         """Gets the target users tweets
 
         This is a modified version of nitter_scraper.tweets.get_tweets().
@@ -133,7 +133,8 @@ class Nitter(DockerBase):
         """
 
         return get_tweets(
-            username=username,
+            query_string=query_string,
+            query_type=query_type,
             pages=pages,
             break_on_tweet_id=break_on_tweet_id,
             address=self.address,

--- a/nitter_scraper/nitter.py
+++ b/nitter_scraper/nitter.py
@@ -113,7 +113,7 @@ class Nitter(DockerBase):
         """
         return get_profile(username=username, not_found_ok=not_found_ok, address=self.address)
 
-    def get_tweets(self, query_string: str, query_type: str, pages: int = 25, break_on_tweet_id: Optional[int] = None):
+    def get_tweets(self, query_string: str, pages: int = 25, break_on_tweet_id: Optional[int] = None):
         """Gets the target users tweets
 
         This is a modified version of nitter_scraper.tweets.get_tweets().
@@ -121,7 +121,7 @@ class Nitter(DockerBase):
         address to scrape profile data.
 
         Args:
-            username: Targeted users username.
+            query_string: Hashtag, if starts with #, cashtag if starts with $, username otherwise
             pages: Max number of pages to lookback starting from the latest tweet.
             break_on_tweet_id: Gives the ability to break out of a loop if a tweets id is found.
             address: The address to scrape from. The default is https://nitter.net which should
@@ -134,7 +134,6 @@ class Nitter(DockerBase):
 
         return get_tweets(
             query_string=query_string,
-            query_type=query_type,
             pages=pages,
             break_on_tweet_id=break_on_tweet_id,
             address=self.address,

--- a/nitter_scraper/tweets.py
+++ b/nitter_scraper/tweets.py
@@ -123,13 +123,14 @@ def timeline_parser(html):
     return html.find(".timeline", first=True)
 
 
-def pagination_parser(timeline, address, username) -> str:
+def pagination_parser(timeline, url) -> str:
     next_page = list(timeline.find(".show-more")[-1].links)[0]
-    return f"{address}/{username}{next_page}"
+    return f"{url}{next_page}"
 
 
 def get_tweets(
-    username: str,
+    query_string: str,
+    query_type: str = 'user',
     pages: int = 25,
     break_on_tweet_id: Optional[int] = None,
     address="https://nitter.net",
@@ -137,7 +138,8 @@ def get_tweets(
     """Gets the target users tweets
 
     Args:
-        username: Targeted users username.
+        query_string: Targeted username, hashtag or cashtag.
+        query_type: Type of former paremeter. Either one of 'user', 'hashtag' or 'cashtag'.
         pages: Max number of pages to lookback starting from the latest tweet.
         break_on_tweet_id: Gives the ability to break out of a loop if a tweets id is found.
         address: The address to scrape from. The default is https://nitter.net which should
@@ -147,7 +149,14 @@ def get_tweets(
         Tweet Objects
 
     """
-    url = f"{address}/{username}"
+    if query_type == 'user':
+        url = f"{address}/{query_string}"
+    elif query_type == 'hashtag':
+        url = f"{address}/search?q=%23{query_string}"
+    elif query_type == 'cashtag':
+        url = f"{address}/search?q=${query_string}"
+    else:
+        raise ValueError(f"Unknown query_type '{query_type}'")
     session = HTMLSession()
 
     def gen_tweets(pages):
@@ -157,7 +166,7 @@ def get_tweets(
             if response.status_code == 200:
                 timeline = timeline_parser(response.html)
 
-                next_url = pagination_parser(timeline, address, username)
+                next_url = pagination_parser(timeline, url)
 
                 timeline_items = timeline.find(".timeline-item")
 

--- a/nitter_scraper/tweets.py
+++ b/nitter_scraper/tweets.py
@@ -130,7 +130,6 @@ def pagination_parser(timeline, url) -> str:
 
 def get_tweets(
     query_string: str,
-    query_type: str = 'user',
     pages: int = 25,
     break_on_tweet_id: Optional[int] = None,
     address="https://nitter.net",
@@ -138,8 +137,7 @@ def get_tweets(
     """Gets the target users tweets
 
     Args:
-        query_string: Targeted username, hashtag or cashtag.
-        query_type: Type of former paremeter. Either one of 'user', 'hashtag' or 'cashtag'.
+        query_string: Hashtag, if starts with #, cashtag if starts with $, username otherwise
         pages: Max number of pages to lookback starting from the latest tweet.
         break_on_tweet_id: Gives the ability to break out of a loop if a tweets id is found.
         address: The address to scrape from. The default is https://nitter.net which should
@@ -149,15 +147,14 @@ def get_tweets(
         Tweet Objects
 
     """
-    if query_type == 'user':
-        url = f"{address}/{query_string}"
-    elif query_type == 'hashtag':
-        url = f"{address}/search?q=%23{query_string}"
-    elif query_type == 'cashtag':
-        url = f"{address}/search?q=${query_string}"
+    if query_string.startswith('#'):
+        url = f"{address}/search?q=%23{query_string[1:]}"
+    elif query_string.startswith('$'):
+        url = f"{address}/search?q={query_string}"
     else:
-        raise ValueError(f"Unknown query_type '{query_type}'")
+        url = f"{address}/{query_string}"
     session = HTMLSession()
+
 
     def gen_tweets(pages):
         response = session.get(url)


### PR DESCRIPTION
This branch adds the ability to download tweets not only for a profile, but also for hashtags or cashtags.

Changes were made to the functions `get_tweets` and `pagination_parser` in `nitter_scraper/tweets.py` and `get_tweets` in `nitter_scraper/nitter.py`. Please tell me if you're okay with the implementation or have suggestions for improvement.

Example usage for hashtags (leading `#`):

```python
import nitter_scraper
from nitter_scraper import NitterScraper

hashtags = ["ToTheMoon"]

print("Scraping with local nitter docker instance.")

with NitterScraper(host="0.0.0.0", port=8008) as nitter:
    for hashtag in hashtags:
        tweets = nitter.get_tweets(hashtag, query_type='hashtag', pages=2)
        for tweet in tweets:
            print()
            pprint(tweet.dict())
            print(tweet.json(indent=4))
```

Example for cashtags (leading `$`):

```python
import nitter_scraper
from nitter_scraper import NitterScraper

cashtags = ["USDT"]

print("Scraping with local nitter docker instance.")

with NitterScraper(host="0.0.0.0", port=8008) as nitter:
    for cashtag in cashtags:
        tweets = nitter.get_tweets(cashtag, query_type='cashtag', pages=2)
        for tweet in tweets:
            print()
            pprint(tweet.dict())
            print(tweet.json(indent=4))
```